### PR TITLE
add roles-based access control middleware

### DIFF
--- a/src/middlewares/role-guard.middleware.ts
+++ b/src/middlewares/role-guard.middleware.ts
@@ -1,0 +1,29 @@
+// src/common/middleware/roles.middleware.ts
+import { Injectable, NestMiddleware, UnauthorizedException, ForbiddenException } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { Reflector } from '@nestjs/core';
+
+@Injectable()
+export class RolesMiddleware implements NestMiddleware {
+    constructor(
+        private readonly reflector: Reflector,
+    ) { }
+
+    async use(req: Request, res: Response, next: NextFunction) {
+        const user = req.user;
+        if (!user) {
+            throw new UnauthorizedException('No user information available');
+        }
+
+        const roles = this.reflector.get<string[]>('roles', req.route);
+        if (!roles || roles.length === 0) {
+            return next();
+        }
+
+        if (!roles.some(role => user.role.type === role)) {
+            throw new ForbiddenException('Forbidden');
+        }
+
+        next();
+    }
+}


### PR DESCRIPTION
Implemented a roles-based access control middleware (RolesMiddleware) in NestJS. This middleware checks if the authenticated user possesses required roles defined in the route metadata using @nestjs/core's Reflector. If the user lacks the necessary role, a ForbiddenException is thrown, otherwise, it allows the request to proceed. 